### PR TITLE
Fix packaging to include all subpackages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include README.md

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@ import sys
 
 from codecs import open
 
-from setuptools import setup
-
+from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -45,7 +44,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-packages = ['evernote2']
+packages = find_packages(include=['evernote2.*'])
 requires = read('requirements.txt')
 test_requirements = read('requirements-dev.txt')
 


### PR DESCRIPTION
https://pypi.org/project/evernote2/#files archives contain only top level files. This PR fixes the packaging by recursive including all subpackages.

See https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

Fixes https://github.com/vitaly-zdanevich/geeknote/actions/runs/8865696077/job/24342241495